### PR TITLE
Fix docker and compose scripts

### DIFF
--- a/cmd/Dockerfile
+++ b/cmd/Dockerfile
@@ -15,7 +15,7 @@ RUN go mod download
 COPY . .
 
 # Build the application
-RUN go build -o bin/distributor ./distributor/cmd
+RUN go build -o bin/distributor ./cmd
 
 # Build release image
 FROM alpine:3.17.3

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -19,8 +19,8 @@ services:
 
   distributor:
     build:
-      context: ..
-      dockerfile: ./distributor/cmd/Dockerfile
+      context: .
+      dockerfile: ./cmd/Dockerfile
     command: [
       "--alsologtostderr",
       "--v=2",


### PR DESCRIPTION
Looks like they've probably been broken since the move over from trillian-examples.
