### PR TITLE
Add TODO at potential feature point

### DIFF
--- a/cmd/internal/distributor/distributor.go
+++ b/cmd/internal/distributor/distributor.go
@@ -125,6 +125,8 @@ func (d *Distributor) GetCheckpointN(ctx context.Context, logID string, n uint32
 	if len(cpsAtSize) >= int(n) {
 		cp, err := checkpoints.Combine(cpsAtSize, l.Verifier, note.VerifierList(witsAtSize...))
 		if err != nil {
+			// TODO(mhutchinson): Keep trying to find some checkpoints that can be merged
+			// but remember to double check we have enough sigs before returning.
 			return nil, fmt.Errorf("failed to combine sigs: %v", err)
 		}
 		return cp, nil


### PR DESCRIPTION
It's unlikely that this will ever save the day, but it would be a shame if it failed to merge adequate checkpoints because _one_ of them was slippery.
