### PR TITLE
Switch from MariaDB to MySQL

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,13 +16,6 @@ The following command will bring up the distributor on port `8080`:
 ```bash
 docker compose up -d
 ```
-
-If using a Raspberry Pi, the above command will fail because no suitable MariaDB image can be
-installed. Instead, use this command to install an image that works:
-```bash
-docker compose -f docker-compose.yaml -f docker-compose.rpi.yaml up -d
-```
-
 ## Support
 * Mailing list: https://groups.google.com/forum/#!forum/trillian-transparency
 * Slack: https://gtrillian.slack.com/ (invitation)

--- a/cmd/internal/distributor/distributor_test.go
+++ b/cmd/internal/distributor/distributor_test.go
@@ -116,9 +116,9 @@ func TestMain(m *testing.M) {
 	// pulls an image, creates a container based on it and runs it
 	resource, err := pool.RunWithOptions(
 		&dockertest.RunOptions{
-			Repository: "mariadb",
-			Tag:        "10.11.2",
-			Env:        []string{"MARIADB_ROOT_PASSWORD=secret"},
+			Repository: "mysql",
+			Tag:        "8.0",
+			Env:        []string{"MYSQL_ROOT_PASSWORD=secret"},
 		},
 		docktest.ConfigureHost)
 	if err != nil {

--- a/docker-compose.rpi.yaml
+++ b/docker-compose.rpi.yaml
@@ -1,5 +1,0 @@
-version: "3.1"
-
-services:
-  db:
-    image: jsurf/rpi-mariadb:latest

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -2,17 +2,17 @@ version: "3.1"
 
 services:
   db:
-    image: mariadb:10.6
+    image: mysql:8.0
     restart: always
     environment:
-      MARIADB_ROOT_PASSWORD: example
-      MARIADB_DATABASE: distributor
-      MARIADB_USER: distributor
-      MARIADB_PASSWORD: letmein
+      MYSQL_ROOT_PASSWORD: example
+      MYSQL_DATABASE: distributor
+      MYSQL_USER: distributor
+      MYSQL_PASSWORD: letmein
     ports:
       - 3306:3306
     healthcheck:
-      test: mariadb --user=$$MARIADB_USER --password=$$MARIADB_PASSWORD --silent --execute "SHOW DATABASES;"
+      test: mysql --user=$$MYSQL_USER --password=$$MYSQL_PASSWORD --silent --execute "SHOW DATABASES;"
       interval: 3s
       timeout: 2s
       retries: 5


### PR DESCRIPTION
Primary motivation is because GCP Cloud SQL supports this setup but not MariaDB
