### PR TITLE
Terraform to deploy DB and image using cloud run

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+/deployment/.terraform
+/deployment/*.tfstate.backup

--- a/deployment/.terraform.lock.hcl
+++ b/deployment/.terraform.lock.hcl
@@ -1,0 +1,40 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/google" {
+  version = "4.83.0"
+  hashes = [
+    "h1:cWBKJt7QJ+MKerSq73qFICJkIsxHn1JepalZzR/eRk4=",
+    "zh:0310360982c3d42449ef103fab0819770aa96c7813507778d71ed016942bed96",
+    "zh:0d0f82ce5e54267641b1f1d494a3ad1ddd41a7553910dd33abd6a114feab6881",
+    "zh:0eda79e53a1833e8692273f5d7224344200e49303e579aec7b53762f50f39210",
+    "zh:3c0cf4abaf461238563132ab4564965bc6bd571eb3bbeedac89258a9a688b169",
+    "zh:61d619e5163daeeb7909443cc0c67816939a1748aec2fe544ab3f380270aae92",
+    "zh:66d9da66aec8575ee16b70b42a5ae082b2f43f4a84a844363a585806ac75cca0",
+    "zh:875c5596f365130095ccc2150755b6fb8a6d9fe9af4af9f595029716be02cdef",
+    "zh:a9af92cd6ea160618d6433c92297a4e3f3dc7a2e964516e1e7b51ce70f3ec178",
+    "zh:b9566bd1910462b4d92c6976184c4408e42a3ef6a300962b49866aa0f6f29b11",
+    "zh:bae735a81a04244893fd9e81d9b5d6c321d874cb37a7b5aab8a1c8c5044b362d",
+    "zh:d97ae1676d793696498e0eda8324bc02edbd2fbbcd76eb103a949876ec1fe8c0",
+    "zh:f569b65999264a9416862bca5cd2a6177d94ccb0424f3a4ef424428912b9cb3c",
+  ]
+}
+
+provider "registry.terraform.io/hashicorp/random" {
+  version = "3.5.1"
+  hashes = [
+    "h1:VSnd9ZIPyfKHOObuQCaKfnjIHRtR7qTw19Rz8tJxm+k=",
+    "zh:04e3fbd610cb52c1017d282531364b9c53ef72b6bc533acb2a90671957324a64",
+    "zh:119197103301ebaf7efb91df8f0b6e0dd31e6ff943d231af35ee1831c599188d",
+    "zh:4d2b219d09abf3b1bb4df93d399ed156cadd61f44ad3baf5cf2954df2fba0831",
+    "zh:6130bdde527587bbe2dcaa7150363e96dbc5250ea20154176d82bc69df5d4ce3",
+    "zh:6cc326cd4000f724d3086ee05587e7710f032f94fc9af35e96a386a1c6f2214f",
+    "zh:78d5eefdd9e494defcb3c68d282b8f96630502cac21d1ea161f53cfe9bb483b3",
+    "zh:b6d88e1d28cf2dfa24e9fdcc3efc77adcdc1c3c3b5c7ce503a423efbdd6de57b",
+    "zh:ba74c592622ecbcef9dc2a4d81ed321c4e44cddf7da799faa324da9bf52a22b2",
+    "zh:c7c5cde98fe4ef1143bd1b3ec5dc04baf0d4cc3ca2c5c7d40d17c0e9b2076865",
+    "zh:dac4bad52c940cd0dfc27893507c1e92393846b024c5a9db159a93c534a3da03",
+    "zh:de8febe2a2acd9ac454b844a4106ed295ae9520ef54dc8ed2faf29f12716b602",
+    "zh:eab0d0495e7e711cca367f7d4df6e322e6c562fc52151ec931176115b83ed014",
+  ]
+}

--- a/deployment/main.tf
+++ b/deployment/main.tf
@@ -1,0 +1,215 @@
+/**
+ * Copyright 2022 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+# Project data
+provider "google" {
+  project = var.project_id
+}
+
+data "google_project" "project" {
+  project_id = var.project_id
+}
+
+# Enable Secret Manager API
+resource "google_project_service" "secretmanager_api" {
+  service            = "secretmanager.googleapis.com"
+  disable_on_destroy = false
+}
+
+# Enable SQL Admin API
+resource "google_project_service" "sqladmin_api" {
+  service            = "sqladmin.googleapis.com"
+  disable_on_destroy = false
+}
+
+# Enable Cloud Run API
+resource "google_project_service" "cloudrun_api" {
+  service            = "run.googleapis.com"
+  disable_on_destroy = false
+}
+
+resource "random_password" "db_root_pwd" {
+  length  = 16
+  special = false
+}
+
+resource "google_secret_manager_secret" "db_root_pass" {
+  secret_id = "dbrootpasssecret"
+  replication {
+    auto {}
+  }
+  depends_on = [google_project_service.secretmanager_api]
+}
+
+resource "google_secret_manager_secret_version" "db_root_pass_data" {
+  secret      = google_secret_manager_secret.db_root_pass.id
+  secret_data = random_password.db_root_pwd.result
+}
+
+# Creates SQL instance (~15 minutes to fully spin up)
+resource "google_sql_database_instance" "default" {
+  name             = "distributor-mysql-instance-1"
+  project          = var.project_id
+  region           = var.region
+  database_version = "MYSQL_8_0"
+  root_password    = random_password.db_root_pwd.result
+
+  settings {
+    tier = "db-f1-micro"
+  }
+  # set `deletion_protection` to true, will ensure that one cannot accidentally delete this instance by
+  # use of Terraform whereas `deletion_protection_enabled` flag protects this instance at the GCP level.
+  deletion_protection = false
+  depends_on          = [google_project_service.sqladmin_api]
+}
+
+resource "random_password" "db_user_pwd" {
+  length  = 16
+  special = false
+}
+
+resource "google_sql_user" "db_user" {
+  name     = "distributor-app"
+  instance = google_sql_database_instance.default.name
+  password = random_password.db_user_pwd.result
+}
+
+# Create dbuser secret
+resource "google_secret_manager_secret" "dbuser" {
+  secret_id = "dbusersecret"
+  replication {
+    auto {}
+  }
+  depends_on = [google_project_service.secretmanager_api]
+}
+
+# Attaches secret data for dbuser secret
+resource "google_secret_manager_secret_version" "dbuser_data" {
+  secret      = google_secret_manager_secret.dbuser.id
+  secret_data = google_sql_user.db_user.name
+}
+
+# Update service account for dbuser secret
+resource "google_secret_manager_secret_iam_member" "secretaccess_compute_dbuser" {
+  secret_id = google_secret_manager_secret.dbuser.id
+  role      = "roles/secretmanager.secretAccessor"
+  member    = "serviceAccount:${data.google_project.project.number}-compute@developer.gserviceaccount.com" # Project's compute service account
+}
+
+# Create dbpass secret
+resource "google_secret_manager_secret" "dbpass" {
+  secret_id = "dbpasssecret"
+  replication {
+    auto {}
+  }
+  depends_on = [google_project_service.secretmanager_api]
+}
+
+# Attaches secret data for dbpass secret
+resource "google_secret_manager_secret_version" "dbpass_data" {
+  secret      = google_secret_manager_secret.dbpass.id
+  secret_data = google_sql_user.db_user.password
+}
+
+# Update service account for dbpass secret
+resource "google_secret_manager_secret_iam_member" "secretaccess_compute_dbpass" {
+  secret_id = google_secret_manager_secret.dbpass.id
+  role      = "roles/secretmanager.secretAccessor"
+  member    = "serviceAccount:${data.google_project.project.number}-compute@developer.gserviceaccount.com" # Project's compute service account
+}
+
+# Create dbname secret
+resource "google_secret_manager_secret" "dbname" {
+  secret_id = "dbnamesecret"
+  replication {
+    auto {}
+  }
+  depends_on = [google_project_service.secretmanager_api]
+}
+
+# Attaches secret data for dbname secret
+resource "google_secret_manager_secret_version" "dbname_data" {
+  secret      = google_secret_manager_secret.dbname.id
+  secret_data = "distributor"
+}
+
+# Update service account for dbname secret
+resource "google_secret_manager_secret_iam_member" "secretaccess_compute_dbname" {
+  secret_id = google_secret_manager_secret.dbname.id
+  role      = "roles/secretmanager.secretAccessor"
+  member    = "serviceAccount:${data.google_project.project.number}-compute@developer.gserviceaccount.com" # Project's compute service account
+}
+
+resource "google_cloud_run_v2_service" "default" {
+  name     = "distributor-service"
+  location = "us-central1"
+
+  template {
+    containers {
+      image = "gcr.io/trillian-opensource-ci/distributor:latest" # Image to deploy
+      args  = [ "--use_cloud_sql" ]
+
+      # Sets a environment variable for instance connection name
+      env {
+        name  = "INSTANCE_CONNECTION_NAME"
+        value = google_sql_database_instance.default.connection_name
+      }
+      # Sets a secret environment variable for database user secret
+      env {
+        name = "DB_USER"
+        value_source {
+          secret_key_ref {
+            secret  = google_secret_manager_secret.dbuser.secret_id # secret name
+            version = "latest"                                      # secret version number or 'latest'
+          }
+        }
+      }
+      # Sets a secret environment variable for database password secret
+      env {
+        name = "DB_PASS"
+        value_source {
+          secret_key_ref {
+            secret  = google_secret_manager_secret.dbpass.secret_id # secret name
+            version = "latest"                                      # secret version number or 'latest'
+          }
+        }
+      }
+      # Sets a secret environment variable for database name secret
+      env {
+        name = "DB_NAME"
+        value_source {
+          secret_key_ref {
+            secret  = google_secret_manager_secret.dbname.secret_id # secret name
+            version = "latest"                                      # secret version number or 'latest'
+          }
+        }
+      }
+
+      volume_mounts {
+        name       = "cloudsql"
+        mount_path = "/cloudsql"
+      }
+    }
+    volumes {
+      name = "cloudsql"
+      cloud_sql_instance {
+        instances = [google_sql_database_instance.default.connection_name]
+      }
+    }
+  }
+  client     = "terraform"
+  depends_on = [google_project_service.secretmanager_api, google_project_service.cloudrun_api, google_project_service.sqladmin_api]
+}

--- a/deployment/outputs.tf
+++ b/deployment/outputs.tf
@@ -1,0 +1,31 @@
+/**
+ * Copyright 2022 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+output "mysql_uri" {
+  description = "The URI of the created resource"
+  value       = google_sql_database_instance.default.self_link
+}
+
+output "mysql_conn" {
+  description = "The connection name of the master instance to be used in connection strings"
+  value       = google_sql_database_instance.default.connection_name
+}
+
+output "distributor_uri" {
+  description = "The main URI in which this Service is serving traffic."
+  value       = google_cloud_run_v2_service.default.uri
+}
+

--- a/deployment/terraform.tfvars
+++ b/deployment/terraform.tfvars
@@ -1,0 +1,2 @@
+project_id        = "checkpoint-distributor"
+region            = "us-central1"

--- a/deployment/variables.tf
+++ b/deployment/variables.tf
@@ -1,0 +1,24 @@
+/**
+ * Copyright 2019 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+variable "project_id" {
+  description = "The project ID to host the cluster in"
+}
+
+variable "region" {
+  description = "The region to host the cluster in"
+}
+


### PR DESCRIPTION
This is almost working as a standalone automation, but the DB creation
within the instance still needs to be performed by hand. I will look
into using a provider to perform this step (and ideally the DDL steps
that the distributor performs in db.init so that the app doesn't need
schema modification permissions).

For now, this works if one has sufficient ACLs for the project and runs:
```bash
terraform init
terraform apply
```

This should bring up the DB and Distributor running in Cloud Run. To
create the Database, the easiest thing to do is to find the instance
within Cloud SQL in GCP UI, and create a database called "distributor".

After doing that, it's possible to query the distributor using curl:
```bash
curl -i -H \
"Authorization: Bearer $(gcloud auth print-identity-token)" \
$DISTRIBUTOR_URI/distributor/v0/logs
```

Note that you'll need to substitute the URI for the new instance that is
created on apply. This is output from `terraform apply` under the name
`distributor_uri` but you can find this in the Cloud Run area of GCP if
you lose it down the back of the sofa.

The messy secret URL is only while this is in experimental. When we have
this launched properly then it will have a public URL and not require
auth tokens.

Also TODO in a future PR before we can take this to prod is to add
integration to make the state be stored in a GCS bucket instead of
output into a local file.
