### PR TITLE
Update terraform docs and script

### DIFF
--- a/deployment/README.md
+++ b/deployment/README.md
@@ -1,9 +1,14 @@
 # Distributor GCP Deployment
 
 This terraform script configures a GCP project with a running distributor.
-When authenticated (via `gcloud`) as a principple with sufficient ACLs for
-the project, terraforming the project can be done with:
 
+First authenticate via `gcloud` as a principle with sufficient ACLs for
+the project:
+```bash
+gcloud auth application-default login
+```
+
+Terraforming the project can be done with:
 ```bash
 # Check that the project and region are right and edit if not!
 cat terraform.tfvars

--- a/deployment/main.tf
+++ b/deployment/main.tf
@@ -41,11 +41,15 @@ resource "google_project_service" "cloudrun_api" {
   disable_on_destroy = false
 }
 
+###
+### Create secrets
+###
+
+## DB root password
 resource "random_password" "db_root_pwd" {
   length  = 16
   special = false
 }
-
 resource "google_secret_manager_secret" "db_root_pass" {
   secret_id = "dbrootpasssecret"
   replication {
@@ -53,13 +57,79 @@ resource "google_secret_manager_secret" "db_root_pass" {
   }
   depends_on = [google_project_service.secretmanager_api]
 }
-
 resource "google_secret_manager_secret_version" "db_root_pass_data" {
   secret      = google_secret_manager_secret.db_root_pass.id
   secret_data = random_password.db_root_pwd.result
 }
 
-# Creates SQL instance (~15 minutes to fully spin up)
+# DB user name
+locals {
+  dbuser = "distributor-app"
+}
+resource "google_secret_manager_secret" "dbuser" {
+  secret_id = "dbusersecret"
+  replication {
+    auto {}
+  }
+  depends_on = [google_project_service.secretmanager_api]
+}
+resource "google_secret_manager_secret_version" "dbuser_data" {
+  secret = google_secret_manager_secret.dbuser.id
+  secret_data = local.dbuser
+}
+
+# DB user password
+resource "random_password" "db_user_pwd" {
+  length  = 16
+  special = false
+}
+resource "google_secret_manager_secret" "dbpass" {
+  secret_id = "dbpasssecret"
+  replication {
+    auto {}
+  }
+  depends_on = [google_project_service.secretmanager_api]
+}
+resource "google_secret_manager_secret_version" "dbpass_data" {
+  secret      = google_secret_manager_secret.dbpass.id
+  secret_data = random_password.db_user_pwd.result
+}
+
+# Database name
+resource "google_secret_manager_secret" "dbname" {
+  secret_id = "dbnamesecret"
+  replication {
+    auto {}
+  }
+  depends_on = [google_project_service.secretmanager_api]
+}
+resource "google_secret_manager_secret_version" "dbname_data" {
+  secret      = google_secret_manager_secret.dbname.id
+  secret_data = "distributor"
+}
+
+###
+### Update service accounts to allow secret access
+###
+resource "google_secret_manager_secret_iam_member" "secretaccess_compute_dbname" {
+  secret_id = google_secret_manager_secret.dbname.id
+  role      = "roles/secretmanager.secretAccessor"
+  member    = "serviceAccount:${data.google_project.project.number}-compute@developer.gserviceaccount.com" # Project's compute service account
+}
+resource "google_secret_manager_secret_iam_member" "secretaccess_compute_dbuser" {
+  secret_id = google_secret_manager_secret.dbuser.id
+  role      = "roles/secretmanager.secretAccessor"
+  member    = "serviceAccount:${data.google_project.project.number}-compute@developer.gserviceaccount.com" # Project's compute service account
+}
+resource "google_secret_manager_secret_iam_member" "secretaccess_compute_dbpass" {
+  secret_id = google_secret_manager_secret.dbpass.id
+  role      = "roles/secretmanager.secretAccessor"
+  member    = "serviceAccount:${data.google_project.project.number}-compute@developer.gserviceaccount.com" # Project's compute service account
+}
+
+###
+### Creates SQL instance (~15 minutes to fully spin up)
+###
 resource "google_sql_database_instance" "default" {
   name             = "distributor-mysql-instance-1"
   project          = var.project_id
@@ -76,83 +146,15 @@ resource "google_sql_database_instance" "default" {
   depends_on          = [google_project_service.sqladmin_api]
 }
 
-resource "random_password" "db_user_pwd" {
-  length  = 16
-  special = false
-}
-
 resource "google_sql_user" "db_user" {
-  name     = "distributor-app"
+  name     = local.dbuser
   instance = google_sql_database_instance.default.name
   password = random_password.db_user_pwd.result
 }
 
-# Create dbuser secret
-resource "google_secret_manager_secret" "dbuser" {
-  secret_id = "dbusersecret"
-  replication {
-    auto {}
-  }
-  depends_on = [google_project_service.secretmanager_api]
-}
-
-# Attaches secret data for dbuser secret
-resource "google_secret_manager_secret_version" "dbuser_data" {
-  secret      = google_secret_manager_secret.dbuser.id
-  secret_data = google_sql_user.db_user.name
-}
-
-# Update service account for dbuser secret
-resource "google_secret_manager_secret_iam_member" "secretaccess_compute_dbuser" {
-  secret_id = google_secret_manager_secret.dbuser.id
-  role      = "roles/secretmanager.secretAccessor"
-  member    = "serviceAccount:${data.google_project.project.number}-compute@developer.gserviceaccount.com" # Project's compute service account
-}
-
-# Create dbpass secret
-resource "google_secret_manager_secret" "dbpass" {
-  secret_id = "dbpasssecret"
-  replication {
-    auto {}
-  }
-  depends_on = [google_project_service.secretmanager_api]
-}
-
-# Attaches secret data for dbpass secret
-resource "google_secret_manager_secret_version" "dbpass_data" {
-  secret      = google_secret_manager_secret.dbpass.id
-  secret_data = google_sql_user.db_user.password
-}
-
-# Update service account for dbpass secret
-resource "google_secret_manager_secret_iam_member" "secretaccess_compute_dbpass" {
-  secret_id = google_secret_manager_secret.dbpass.id
-  role      = "roles/secretmanager.secretAccessor"
-  member    = "serviceAccount:${data.google_project.project.number}-compute@developer.gserviceaccount.com" # Project's compute service account
-}
-
-# Create dbname secret
-resource "google_secret_manager_secret" "dbname" {
-  secret_id = "dbnamesecret"
-  replication {
-    auto {}
-  }
-  depends_on = [google_project_service.secretmanager_api]
-}
-
-# Attaches secret data for dbname secret
-resource "google_secret_manager_secret_version" "dbname_data" {
-  secret      = google_secret_manager_secret.dbname.id
-  secret_data = "distributor"
-}
-
-# Update service account for dbname secret
-resource "google_secret_manager_secret_iam_member" "secretaccess_compute_dbname" {
-  secret_id = google_secret_manager_secret.dbname.id
-  role      = "roles/secretmanager.secretAccessor"
-  member    = "serviceAccount:${data.google_project.project.number}-compute@developer.gserviceaccount.com" # Project's compute service account
-}
-
+###
+### Set up Cloud Run service
+###
 resource "google_cloud_run_v2_service" "default" {
   name     = "distributor-service"
   location = "us-central1"


### PR DESCRIPTION
The script was being flaky, failing to start cloud run because secrets were not available. Changed to provision all of the secrets and read access to them earlier so these can propagate while the rest of the script is running. This also makes it easier to read, as all of the secrets are in the same place.