### PR TITLE
Added dev armored witness keys so we can test end-to-end

### DIFF
--- a/cmd/witnesses.yaml
+++ b/cmd/witnesses.yaml
@@ -2,3 +2,6 @@ Witnesses:
   - mhutchinson.witness+384b3dbc+AfWg+7+qmcFoMuIM0ZGe4ZsIuc6gEg3EL0cKkNVolCA+
   - wolsey-bank-alfred+0336ecb0+AVcofP6JyFkxhQ+/FK7omBtGLVS22tGC6fH+zvK5WrIx
   - JKU-INS+814e35bf+AdYBKkmgKGzao81EKOSxkphZLDtgBf72VXHFOIhMmqvO
+  - DEV:ArmoredWitness-quiet-hill+36ccdbc6+AYla/cX7GRGOIBg9nM9PFZANcMLAR2XLR0nD9V8siErf
+  - DEV:ArmoredWitness-dawn-moon+271aa3a3+Abnd4ZwWVrpW9ioej/UDgP1YUaWI94YmIJPJHcXocnLM
+  - DEV:ArmoredWitness-black-butterfly+0f47d516+ActqdOBIMdh5t1QvQ81b9sBVX43khgsJ7ygttnDrIC1h


### PR DESCRIPTION
A reminder that the long play for this configuration is that the keys will be read from a log. For now, they are read from this file which is statically compiled into the binary. This can be overridden with --witness_config_file.
