### PR TITLE
Updated Slack channel details

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![Go Reference](https://pkg.go.dev/badge/github.com/transparency-dev/distributor.svg)](https://pkg.go.dev/github.com/transparency-dev/distributor)
 [![Go Report Card](https://goreportcard.com/badge/github.com/transparency-dev/distributor)](https://goreportcard.com/report/github.com/transparency-dev/distributor)
 [![OpenSSF Scorecard](https://api.securityscorecards.dev/projects/github.com/transparency-dev/distributor/badge)](https://securityscorecards.dev/viewer/?uri=github.com/transparency-dev/distributor)
-[![Slack Status](https://img.shields.io/badge/Slack-Chat-blue.svg)](https://gtrillian.slack.com/)
+[![Slack Status](https://img.shields.io/badge/Slack-Chat-blue.svg)](https://transparency-dev.slack.com/)
 
 ## Overview
 
@@ -18,4 +18,4 @@ docker compose up -d
 ```
 ## Support
 * Mailing list: https://groups.google.com/forum/#!forum/trillian-transparency
-* Slack: https://gtrillian.slack.com/ (invitation)
+- Slack: https://transparency-dev.slack.com/ ([invitation](https://join.slack.com/t/transparency-dev/shared_invite/zt-27pkqo21d-okUFhur7YZ0rFoJVIOPznQ))


### PR DESCRIPTION
Old slack channel will stay around for a while, but we're migrating over to a new channel that encompasses a broader transparency community that includes witness distribution and other transparency topics.
