### PR TITLE
Allow the witness identities to be provided as flags

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -85,7 +85,7 @@ func ParseWitnessesConfig(y []byte) (map[uint32]note.Verifier, error) {
 	witCfg := struct {
 		Witnesses []string `yaml:"Witnesses"`
 	}{}
-	if err := yaml.Unmarshal(WitnessesYAML, &witCfg); err != nil {
+	if err := yaml.Unmarshal(y, &witCfg); err != nil {
 		return nil, fmt.Errorf("failed to unmarshal witness config: %v", err)
 	}
 	ws := make(map[uint32]note.Verifier)


### PR DESCRIPTION
This will allow us to easily configure the CI and dev environments from CloudRun. The configuration file option cannot be used because of the nature of cloud run not having a file system. The other option would be to allow the config file to be read from a URL, or GCS, but this option is cleaner.

Also fixed a bug where it was always parsing the built-in configuration
instead of whatever was provided at runtime.
