### PR TITLE
Allow witness IDs to be routed to binary on a per-env basis

### DIFF
--- a/deployment/live/dev/terragrunt.hcl
+++ b/deployment/live/dev/terragrunt.hcl
@@ -15,6 +15,11 @@ inputs = merge(
   {
     docker_tag = "latest"
     env        = "dev"
+    extra_args = [
+      "--witkey=mhutchinson.witness+384b3dbc+AfWg+7+qmcFoMuIM0ZGe4ZsIuc6gEg3EL0cKkNVolCA+",
+      "--witkey=wolsey-bank-alfred+0336ecb0+AVcofP6JyFkxhQ+/FK7omBtGLVS22tGC6fH+zvK5WrIx",
+      "--witkey=JKU-INS+814e35bf+AdYBKkmgKGzao81EKOSxkphZLDtgBf72VXHFOIhMmqvO",
+    ]
   }
 )
 

--- a/deployment/modules/distributor/main.tf
+++ b/deployment/modules/distributor/main.tf
@@ -152,11 +152,11 @@ resource "google_cloud_run_v2_service" "default" {
   template {
     containers {
       image = "gcr.io/trillian-opensource-ci/distributor:${var.docker_tag}" # Image to deploy
-      args = [
+      args = concat([
         "--logtostderr",
         "--v=1",
         "--use_cloud_sql",
-      ]
+      ], var.extra_args)
 
       env {
         name  = "INSTANCE_CONNECTION_NAME"

--- a/deployment/modules/distributor/variables.tf
+++ b/deployment/modules/distributor/variables.tf
@@ -34,6 +34,12 @@ variable "docker_tag" {
   type        = string
 }
 
+variable "extra_args" {
+  description = "Extra arguments to be provided to the distributor invoked in cloud run"
+  type        = list(string)
+  default     = []
+}
+
 variable "network_name" {
   default = "mysql-private"
   type    = string


### PR DESCRIPTION
CI and prod environments are untouched from this change. The dev environment is now configured with the non-AW omniwitness keys by known operators.
