### PR TITLE
Export metrics on main port

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -29,7 +29,6 @@ services:
     ]
     ports:
      - "8080:8080"
-     - "8081:8081"
     restart: always
     depends_on:
       db:


### PR DESCRIPTION
CloudRun doesn't allow services to expose multiple ports, thus it wasn't possible to scrape these metrics when exported on a different port. This changes the metrics to be exported on the default port, but the registration can be disabled via a flag in case we want to turn this off.
