### PR TITLE
distributor startup probe

### DIFF
--- a/deployment/modules/distributor/main.tf
+++ b/deployment/modules/distributor/main.tf
@@ -196,6 +196,9 @@ resource "google_cloud_run_v2_service" "default" {
         "--v=1",
         "--use_cloud_sql",
       ], var.extra_args)
+      ports {
+        container_port = 8080
+      }
 
       env {
         name  = "INSTANCE_CONNECTION_NAME"
@@ -217,6 +220,16 @@ resource "google_cloud_run_v2_service" "default" {
             secret  = google_secret_manager_secret.dbpass.secret_id # secret name
             version = "latest"                                      # secret version number or 'latest'
           }
+        }
+      }
+
+      startup_probe {
+        initial_delay_seconds = 1
+        timeout_seconds = 1
+        period_seconds = 3
+        failure_threshold = 1
+        tcp_socket {
+          port = 8080
         }
       }
 

--- a/deployment/modules/distributor/main.tf
+++ b/deployment/modules/distributor/main.tf
@@ -226,8 +226,8 @@ resource "google_cloud_run_v2_service" "default" {
       startup_probe {
         initial_delay_seconds = 1
         timeout_seconds = 1
-        period_seconds = 3
-        failure_threshold = 1
+        period_seconds = 10
+        failure_threshold = 3
         tcp_socket {
           port = 8080
         }


### PR DESCRIPTION
- Use custom service account to run distributor
- Set up dependencies to avoid cloud run being started before permissions available
- Add startup probe for distributor health
