### PR TITLE
Override the Slack template with a custom version

### DIFF
--- a/deployment/live/cloudbuild/dev/slack.json
+++ b/deployment/live/cloudbuild/dev/slack.json
@@ -1,0 +1,30 @@
+[
+    {
+      "type": "section",
+      "text": {
+        "type": "mrkdwn",
+        "text": "Cloud Build {{.Build.ProjectId}} {{.Build.Id}} {{.Build.Status}}"
+      }
+    },
+    {
+      "type": "divider"
+    },
+    {
+      "type": "section",
+      "text": {
+        "type": "mrkdwn",
+        "text": "View Build Logs"
+      },
+      "accessory": {
+        "type": "button",
+        "text": {
+          "type": "plain_text",
+          "text": "Logs"
+        },
+        "value": "click_me_123",
+        "url": "{{.Build.LogUrl}}",
+        "action_id": "button-action"
+      }
+    }
+  ]
+  

--- a/deployment/live/cloudbuild/dev/terragrunt.hcl
+++ b/deployment/live/cloudbuild/dev/terragrunt.hcl
@@ -13,8 +13,9 @@ locals {
 inputs = merge(
   local.common_vars.locals,
   {
-    env               = "dev"
-    cloud_run_service = "distributor-service-dev"
+    env                 = "dev"
+    cloud_run_service   = "distributor-service-dev"
+    slack_template_json = file("slack.json")
   }
 )
 

--- a/deployment/modules/cloudbuild/main.tf
+++ b/deployment/modules/cloudbuild/main.tf
@@ -110,9 +110,10 @@ resource "google_project_iam_member" "cloudrun_deployer" {
 }
 
 module "cloud-build-slack-notifier" {
-  # This should be set back to the registry version when the following is merged:
+  # This should be set back to the registry version when the following are merged:
   # https://github.com/simplifi/terraform-google-cloud-build-slack-notifier/pull/8
-  source     = "github.com/mhutchinson/terraform-google-cloud-build-slack-notifier"
+  # https://github.com/simplifi/terraform-google-cloud-build-slack-notifier/pull/9
+  source     = "github.com/mhutchinson/terraform-google-cloud-build-slack-notifier?ref=4e525d3"
   # source  = "simplifi/cloud-build-slack-notifier/google"
   # version = "0.3.0"
 
@@ -122,5 +123,7 @@ module "cloud-build-slack-notifier" {
   # https://api.slack.com/apps/A06KYD43DPE/incoming-webhooks
   slack_webhook_url_secret_id      = "gcb_slack_webhook_${var.env}"
   slack_webhook_url_secret_project = var.project_id
+
+  override_slack_template_json = var.slack_template_json
 }
 

--- a/deployment/modules/cloudbuild/variables.tf
+++ b/deployment/modules/cloudbuild/variables.tf
@@ -34,3 +34,9 @@ variable "cloud_run_service" {
   type        = string
 }
 
+variable "slack_template_json" {
+  description = "Contents of the Slack template (https://cloud.google.com/build/docs/configuring-notifications/configure-slack#configuring_slack_notifications)"
+  type        = string
+  default     = ""
+}
+


### PR DESCRIPTION
The last version didn't actually work because the module didn't create the required json template. I've made some more changes to my fork that creates a default json template that can be overridden. We override that here with a custom template. This allows us to play around with the Slack template until we're happy with the notifications in dev, before promoting that to prod.
