### PR TITLE
Prod notifications in Slack for CloudBuild activity

### DIFF
--- a/deployment/live/cloudbuild/README.md
+++ b/deployment/live/cloudbuild/README.md
@@ -13,3 +13,18 @@ Error: Error creating Trigger: googleapi: Error 400: Repository mapping does not
 
 This is a manual one-time step that needs to be followed to integrate GCB and the GitHub project.
 
+### Slack notifications
+
+Each cloudbuild environment sets up a Slack integration. This requires:
+ 1. A webhook to have been created in a Slack app (https://api.slack.com/apps/A06KYD43DPE/incoming-webhooks)
+ 2. This webhook URL has been stored as a secret in Secret Manager in cloud
+
+One unfortunate issue is that there is a common dependency on the pubsub topic `cloud-builds`.
+The first environment will create this, and other environments will then fail to create it because the name is in use.
+To work around this:
+
+```
+terragrunt import module.cloud-build-slack-notifier.google_pubsub_topic.cloud_builds projects/checkpoint-distributor/topics/cloud-builds
+```
+
+This imports the resource into this configuration, and running `terragrunt apply` again after this should work.

--- a/deployment/live/cloudbuild/prod/.terraform.lock.hcl
+++ b/deployment/live/cloudbuild/prod/.terraform.lock.hcl
@@ -20,3 +20,43 @@ provider "registry.terraform.io/hashicorp/google" {
     "zh:f913a0e0708391ccd26fc3458158cc1e10d68dc621bef3a1583328c61a77225d",
   ]
 }
+
+provider "registry.terraform.io/hashicorp/google-beta" {
+  version     = "5.17.0"
+  constraints = ">= 3.30.0"
+  hashes = [
+    "h1:g0D9UoAD+6PnUHWTwzelN46a0Vhfvb1A3nbbIHb+x4k=",
+    "zh:14f5dc5273c66c5be4e9d8c0c25faa3654f8428a337b7c366222f7e25a023460",
+    "zh:19280f1d390b87ec08962356c44fbec65866d6c3394d73c5671f83e9cbd7ba5f",
+    "zh:2c8857afaf87bb34f9696ddb803ecdeb97158533e16164dec7d4fd55f08c222d",
+    "zh:2f0fcb5ea80191c6bea605b2a4f23a8be1dd52c2fcc0add652ed5d00300ab13b",
+    "zh:7523d307c93f5f5f51f5d27c4b3ea3a66abc86be43357bbb4c7629e53997662c",
+    "zh:889d7e1cb3638248898b30c656f512841a422416dc2467357c567b2d05e1fafb",
+    "zh:908fed36796c2e6f3fd71d6a9d00d97ae2224d4665984f5f2a4fdc158bfbc67d",
+    "zh:95a8d09c628f857bdfcc4ca2aadb029ebed2757b7c01ba005ccf5118080b1139",
+    "zh:b776986aceab76147b8be59ac34360a5cfa2014d83263e0b2c225452f11ce7c0",
+    "zh:f1d10391977e071fdc8027d15929ac70983759270b85a35e5e5ca5f232eac787",
+    "zh:f569b65999264a9416862bca5cd2a6177d94ccb0424f3a4ef424428912b9cb3c",
+    "zh:fff1ad7a3608f7f7b9ee04eba0c2e1c125013296d016fc23daa081d7584a1f53",
+  ]
+}
+
+provider "registry.terraform.io/hashicorp/random" {
+  version     = "3.6.0"
+  constraints = ">= 2.1.0"
+  hashes = [
+    "h1:R5Ucn26riKIEijcsiOMBR3uOAjuOMfI1x7XvH4P6B1w=",
+    "zh:03360ed3ecd31e8c5dac9c95fe0858be50f3e9a0d0c654b5e504109c2159287d",
+    "zh:1c67ac51254ba2a2bb53a25e8ae7e4d076103483f55f39b426ec55e47d1fe211",
+    "zh:24a17bba7f6d679538ff51b3a2f378cedadede97af8a1db7dad4fd8d6d50f829",
+    "zh:30ffb297ffd1633175d6545d37c2217e2cef9545a6e03946e514c59c0859b77d",
+    "zh:454ce4b3dbc73e6775f2f6605d45cee6e16c3872a2e66a2c97993d6e5cbd7055",
+    "zh:78d5eefdd9e494defcb3c68d282b8f96630502cac21d1ea161f53cfe9bb483b3",
+    "zh:91df0a9fab329aff2ff4cf26797592eb7a3a90b4a0c04d64ce186654e0cc6e17",
+    "zh:aa57384b85622a9f7bfb5d4512ca88e61f22a9cea9f30febaa4c98c68ff0dc21",
+    "zh:c4a3e329ba786ffb6f2b694e1fd41d413a7010f3a53c20b432325a94fa71e839",
+    "zh:e2699bc9116447f96c53d55f2a00570f982e6f9935038c3810603572693712d0",
+    "zh:e747c0fd5d7684e5bfad8aa0ca441903f15ae7a98a737ff6aca24ba223207e2c",
+    "zh:f1ca75f417ce490368f047b63ec09fd003711ae48487fba90b4aba2ccf71920e",
+  ]
+}

--- a/deployment/live/cloudbuild/prod/slack.json
+++ b/deployment/live/cloudbuild/prod/slack.json
@@ -1,0 +1,30 @@
+[
+    {
+      "type": "section",
+      "text": {
+        "type": "mrkdwn",
+        "text": "Cloud Build {{.Build.ProjectId}} {{.Build.Id}} {{.Build.Status}}"
+      }
+    },
+    {
+      "type": "divider"
+    },
+    {
+      "type": "section",
+      "text": {
+        "type": "mrkdwn",
+        "text": "View Build Logs"
+      },
+      "accessory": {
+        "type": "button",
+        "text": {
+          "type": "plain_text",
+          "text": "Logs"
+        },
+        "value": "click_me_123",
+        "url": "{{.Build.LogUrl}}",
+        "action_id": "button-action"
+      }
+    }
+  ]
+  

--- a/deployment/live/cloudbuild/prod/terragrunt.hcl
+++ b/deployment/live/cloudbuild/prod/terragrunt.hcl
@@ -13,8 +13,9 @@ locals {
 inputs = merge(
   local.common_vars.locals,
   {
-    env               = "prod"
-    cloud_run_service = "distributor-service-ci"
+    env                 = "prod"
+    cloud_run_service   = "distributor-service-ci"
+    slack_template_json = file("slack.json")
   }
 )
 

--- a/deployment/modules/cloudbuild/main.tf
+++ b/deployment/modules/cloudbuild/main.tf
@@ -117,7 +117,7 @@ module "cloud-build-slack-notifier" {
   # source  = "simplifi/cloud-build-slack-notifier/google"
   # version = "0.3.0"
 
-  name       = "gcp-slack-notifier-${var.env}"
+  name       = "gcp-slack-${var.env}"
   project_id = var.project_id
   
   # https://api.slack.com/apps/A06KYD43DPE/incoming-webhooks


### PR DESCRIPTION
This sets up the "prod" environment which talks to the public cloudbuild-notifications channel. The names of the resources needed to be shortened in the main module because the extra character in the env name was too long.