### PR TITLE
Clean up some TODOs

### DIFF
--- a/cmd/internal/distributor/distributor_test.go
+++ b/cmd/internal/distributor/distributor_test.go
@@ -750,7 +750,7 @@ func TestGetCheckpointNHistoric(t *testing.T) {
 			wantSize: 22,
 		},
 		{
-			desc: "TODO: N=2 can get historic version where both were in sync together",
+			desc: "N=2 can get historic version where both were in sync together",
 			order: []witnessAndSize{
 				{
 					witChameleon,
@@ -788,7 +788,7 @@ func TestGetCheckpointNHistoric(t *testing.T) {
 			reqN:        2,
 			wantErr:     true,
 			wantErrCode: codes.NotFound,
-			// TODO(mhutchinson): this case should work with the following assertions
+			// TODO(#103): this case should work with the following assertions
 			// wantErr: false,
 			// wantSize: 10,
 		},

--- a/deployment/modules/cloudbuild/main.tf
+++ b/deployment/modules/cloudbuild/main.tf
@@ -42,7 +42,6 @@ resource "google_cloudbuild_trigger" "distributor_docker" {
     }
   }
 
-  # TODO(mhutchinson): Consider replacing this with https://github.com/ko-build/terraform-provider-ko
   build {
     step {
       name = "gcr.io/cloud-builders/docker"


### PR DESCRIPTION
The ko builder doesn't really work for our deployment because it does the build at the point where terraform is run, not hooked into cloud build.
