### PR TITLE
Slack notifications are filtered to channels based on env

### DIFF
--- a/deployment/modules/cloudbuild/main.tf
+++ b/deployment/modules/cloudbuild/main.tf
@@ -115,6 +115,8 @@ module "cloud-build-slack-notifier" {
   name       = "gcp-slack-${var.env}"
   project_id = var.project_id
 
+  cloud_build_event_filter = "build.substitutions['BRANCH_NAME'] == 'main' && build.status in [Build.Status.SUCCESS, Build.Status.FAILURE, Build.Status.TIMEOUT] && build.substitutions['TRIGGER_NAME'].endsWith('-${var.env}')"
+
   # https://api.slack.com/apps/A06KYD43DPE/incoming-webhooks
   slack_webhook_url_secret_id      = "gcb_slack_webhook_${var.env}"
   slack_webhook_url_secret_project = var.project_id


### PR DESCRIPTION
Builds triggered by the -dev trigger go to cloudbuild-dev, and ones from the -prod trigger go to the public channel. This cuts down on a lot of duplicate noise, and means that we can test in dev without creating concern that everything is broken on the public channel.

Note that the first parts of the filter are all the same as the default value for this predicate. The only diff is the trigger.endsWith.
