### PR TITLE
Tag docker images with git hashes and tags

### DIFF
--- a/deployment/modules/cloudbuild/main.tf
+++ b/deployment/modules/cloudbuild/main.tf
@@ -82,7 +82,7 @@ resource "google_cloudbuild_trigger" "distributor_docker" {
 }
 
 # When a new tag is pushed to GitHub, add that tag to the docker
-# iamge that was already pushed to the repo for the corresponding
+# image that was already pushed to the repo for the corresponding
 # commit hash.
 # This requires that the above step has already completed, but that
 # seems like a fair assumption given that we'd have deployed it in ci

--- a/deployment/modules/cloudbuild/outputs.tf
+++ b/deployment/modules/cloudbuild/outputs.tf
@@ -29,7 +29,7 @@ output "cloudbuild_trigger_id" {
   value       = google_cloudbuild_trigger.distributor_docker.id
 }
 
-output "docker_image_latest" {
-  description = "The address of the latest docker image that will be built"
+output "docker_image" {
+  description = "The address of the docker image that will be built"
   value       = local.docker_image
 }

--- a/deployment/modules/cloudbuild/outputs.tf
+++ b/deployment/modules/cloudbuild/outputs.tf
@@ -31,5 +31,5 @@ output "cloudbuild_trigger_id" {
 
 output "docker_image_latest" {
   description = "The address of the latest docker image that will be built"
-  value       = local.docker_address
+  value       = local.docker_image
 }


### PR DESCRIPTION
The build step that previously existed now adds the short commit SHA as a docker tag, in addition to latest.

There is an additional trigger that fires on tags that will pull the docker image with the commit SHA corresponding to the tag, and then push it with the git tag as a docker tag.
