### PR TITLE
Use the 0.1.1 release in prod

### DIFF
--- a/deployment/live/serving/prod/terragrunt.hcl
+++ b/deployment/live/serving/prod/terragrunt.hcl
@@ -14,7 +14,7 @@ inputs = merge(
   local.common_vars.locals,
   {
     env                      = "prod"
-    distributor_docker_image = "us-central1-docker.pkg.dev/checkpoint-distributor/distributor-docker-prod/distributor:v0.1.0"
+    distributor_docker_image = "us-central1-docker.pkg.dev/checkpoint-distributor/distributor-docker-prod/distributor:v0.1.1"
   }
 )
 


### PR DESCRIPTION
This ensures we don't have any known vulnerabilities in the docker images we're running. This has already been rolled out.
