### PR TITLE
Terraform: set witnesses per environment

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,13 @@ The following command will bring up the distributor on port `8080`:
 ```bash
 docker compose up -d
 ```
+
+Note that this will only accept witnessed checkpoints from witnesses in the
+`config/witnesses-dev.yaml` directory.
+To change the permitted witnesses, modify the `docker-compose.yaml` file to
+include a different file, or configure the distributor binary with the witnesses
+specified directly via the `witKey` flag.
+
 ## Support
 * Mailing list: https://groups.google.com/forum/#!forum/trillian-transparency
 - Slack: https://transparency-dev.slack.com/ ([invitation](https://join.slack.com/t/transparency-dev/shared_invite/zt-27pkqo21d-okUFhur7YZ0rFoJVIOPznQ))

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -183,8 +183,7 @@ func getWitnessesOrDie() map[string]note.Verifier {
 			glog.Exitf("Failed to marshal witness config: %v", err)
 		}
 	} else if !witFile && !witFlags {
-		glog.Info("Flags witness_config_file nor witkey are specified; default witness list will be used")
-		cfg = config.WitnessesYAML
+		glog.Exitf("Neither flags witness_config_file nor witkey are specified")
 	} else {
 		glog.Exitf("Only one of witness_config_file and witkey can be specified")
 	}

--- a/config/config.go
+++ b/config/config.go
@@ -29,21 +29,12 @@ import (
 var (
 	//go:embed logs.yaml
 	LogsYAML []byte
-
-	//go:embed witnesses.yaml
-	WitnessesYAML []byte
 )
 
 // DefaultLogs returns a parsed representation of the embedded LogsYAML config.
 // The returned map is keyed by LogID.
 func DefaultLogs() (map[string]LogInfo, error) {
 	return ParseLogConfig(LogsYAML)
-}
-
-// DeafultWitnesses returns a parsed representation of the embedded WitnessesYAML config.
-// The returned map is keyed by the raw verifier key string.
-func DefaultWitnesses() (map[string]note.Verifier, error) {
-	return ParseWitnessesConfig(WitnessesYAML)
 }
 
 // LogInfo contains the information that the distributor needs to know about

--- a/config/witnesses-ci.yaml
+++ b/config/witnesses-ci.yaml
@@ -1,7 +1,4 @@
 Witnesses:
-  - mhutchinson.witness+384b3dbc+AfWg+7+qmcFoMuIM0ZGe4ZsIuc6gEg3EL0cKkNVolCA+
-  - wolsey-bank-alfred+0336ecb0+AVcofP6JyFkxhQ+/FK7omBtGLVS22tGC6fH+zvK5WrIx
-  - JKU-INS+814e35bf+AdYBKkmgKGzao81EKOSxkphZLDtgBf72VXHFOIhMmqvO
   - DEV:ArmoredWitness-quiet-hill+36ccdbc6+AYla/cX7GRGOIBg9nM9PFZANcMLAR2XLR0nD9V8siErf
   - DEV:ArmoredWitness-dawn-moon+271aa3a3+Abnd4ZwWVrpW9ioej/UDgP1YUaWI94YmIJPJHcXocnLM
   - DEV:ArmoredWitness-black-butterfly+0f47d516+ActqdOBIMdh5t1QvQ81b9sBVX43khgsJ7ygttnDrIC1h

--- a/config/witnesses-dev.yaml
+++ b/config/witnesses-dev.yaml
@@ -1,0 +1,4 @@
+Witnesses:
+  - mhutchinson.witness+384b3dbc+AfWg+7+qmcFoMuIM0ZGe4ZsIuc6gEg3EL0cKkNVolCA+
+  - wolsey-bank-alfred+0336ecb0+AVcofP6JyFkxhQ+/FK7omBtGLVS22tGC6fH+zvK5WrIx
+  - JKU-INS+814e35bf+AdYBKkmgKGzao81EKOSxkphZLDtgBf72VXHFOIhMmqvO

--- a/config/witnesses-prod.yaml
+++ b/config/witnesses-prod.yaml
@@ -1,0 +1,8 @@
+Witnesses:
+  - DEV:ArmoredWitness-quiet-hill+36ccdbc6+AYla/cX7GRGOIBg9nM9PFZANcMLAR2XLR0nD9V8siErf
+  - DEV:ArmoredWitness-dawn-moon+271aa3a3+Abnd4ZwWVrpW9ioej/UDgP1YUaWI94YmIJPJHcXocnLM
+  - DEV:ArmoredWitness-black-butterfly+0f47d516+ActqdOBIMdh5t1QvQ81b9sBVX43khgsJ7ygttnDrIC1h
+  - DEV:ArmoredWitness-damp-bush+b4b96347+ARu8kWgrwMnvwCssl4eLtBcwneGI71lxPpSyzv3XryWq
+  - DEV:ArmoredWitness-snowy-glitter+178c58ea+AQhDuxEMjIFXsuwvIaU27VHdR9yVwzaVG78x5X9rYBcA
+  - DEV:ArmoredWitness-red-flower+0dd76e7d+AfghO156ld4kR1E0M22sYhhg+Vjx9PX1TVORR7Hsjot9
+  - DEV:ArmoredWitness-holy-moon+dc5342fa+AaczuSJluywheIiocZvenEh8hpU+Z9SkIU5DwlP1zun5

--- a/deployment/live/serving/ci/terragrunt.hcl
+++ b/deployment/live/serving/ci/terragrunt.hcl
@@ -1,24 +1,17 @@
-include {
-  path = find_in_parent_folders()
+include "root" {
+  path   = find_in_parent_folders()
+  expose = true
 }
 
 terraform {
-  source = "${get_path_to_repo_root()}/deployment/modules/distributor"
-}
-
-locals {
-  env           = "ci"
-  common_vars   = read_terragrunt_config(find_in_parent_folders())
-  witnesses_raw = yamldecode(file("${get_path_to_repo_root()}/config/witnesses-${local.env}.yaml"))
-  witnessArgs   = [for w in local.witnesses_raw.Witnesses : "--witkey=${w}"]
+  source = "${get_repo_root()}/deployment/modules/distributor"
 }
 
 inputs = merge(
-  local.common_vars.locals,
+  include.root.locals,
   {
-    env                      = local.env
     distributor_docker_image = "us-central1-docker.pkg.dev/checkpoint-distributor/distributor-docker-prod/distributor:latest"
-    extra_args               = local.witnessArgs
+    extra_args               = include.root.locals.witnessArgs
   }
 )
 

--- a/deployment/live/serving/ci/terragrunt.hcl
+++ b/deployment/live/serving/ci/terragrunt.hcl
@@ -3,10 +3,6 @@ include "root" {
   expose = true
 }
 
-terraform {
-  source = "${get_repo_root()}/deployment/modules/distributor"
-}
-
 inputs = merge(
   include.root.locals,
   {

--- a/deployment/live/serving/ci/terragrunt.hcl
+++ b/deployment/live/serving/ci/terragrunt.hcl
@@ -7,14 +7,18 @@ terraform {
 }
 
 locals {
-  common_vars = read_terragrunt_config(find_in_parent_folders())
+  env           = "ci"
+  common_vars   = read_terragrunt_config(find_in_parent_folders())
+  witnesses_raw = yamldecode(file("${get_path_to_repo_root()}/config/witnesses-${local.env}.yaml"))
+  witnessArgs   = [for w in local.witnesses_raw.Witnesses : "--witkey=${w}"]
 }
 
 inputs = merge(
   local.common_vars.locals,
   {
-    env                      = "ci"
+    env                      = local.env
     distributor_docker_image = "us-central1-docker.pkg.dev/checkpoint-distributor/distributor-docker-prod/distributor:latest"
+    extra_args               = local.witnessArgs
   }
 )
 

--- a/deployment/live/serving/dev/terragrunt.hcl
+++ b/deployment/live/serving/dev/terragrunt.hcl
@@ -7,19 +7,18 @@ terraform {
 }
 
 locals {
-  common_vars = read_terragrunt_config(find_in_parent_folders())
+  env           = "dev"
+  common_vars   = read_terragrunt_config(find_in_parent_folders())
+  witnesses_raw = yamldecode(file("${get_path_to_repo_root()}/config/witnesses-${local.env}.yaml"))
+  witnessArgs   = [for w in local.witnesses_raw.Witnesses : "--witkey=${w}"]
 }
 
 inputs = merge(
   local.common_vars.locals,
   {
-    env                      = "dev"
+    env                      = local.env
     distributor_docker_image = "us-central1-docker.pkg.dev/checkpoint-distributor/distributor-docker-dev/distributor:latest"
-    extra_args               = [
-      "--witkey=mhutchinson.witness+384b3dbc+AfWg+7+qmcFoMuIM0ZGe4ZsIuc6gEg3EL0cKkNVolCA+",
-      "--witkey=wolsey-bank-alfred+0336ecb0+AVcofP6JyFkxhQ+/FK7omBtGLVS22tGC6fH+zvK5WrIx",
-      "--witkey=JKU-INS+814e35bf+AdYBKkmgKGzao81EKOSxkphZLDtgBf72VXHFOIhMmqvO",
-    ]
+    extra_args               = local.witnessArgs
   }
 )
 

--- a/deployment/live/serving/dev/terragrunt.hcl
+++ b/deployment/live/serving/dev/terragrunt.hcl
@@ -1,24 +1,17 @@
-include {
-  path = find_in_parent_folders()
+include "root" {
+  path   = find_in_parent_folders()
+  expose = true
 }
 
 terraform {
-  source = "${get_path_to_repo_root()}/deployment/modules/distributor"
-}
-
-locals {
-  env           = "dev"
-  common_vars   = read_terragrunt_config(find_in_parent_folders())
-  witnesses_raw = yamldecode(file("${get_path_to_repo_root()}/config/witnesses-${local.env}.yaml"))
-  witnessArgs   = [for w in local.witnesses_raw.Witnesses : "--witkey=${w}"]
+  source = "${get_repo_root()}/deployment/modules/distributor"
 }
 
 inputs = merge(
-  local.common_vars.locals,
+  include.root.locals,
   {
-    env                      = local.env
     distributor_docker_image = "us-central1-docker.pkg.dev/checkpoint-distributor/distributor-docker-dev/distributor:latest"
-    extra_args               = local.witnessArgs
+    extra_args               = include.root.locals.witnessArgs
   }
 )
 

--- a/deployment/live/serving/dev/terragrunt.hcl
+++ b/deployment/live/serving/dev/terragrunt.hcl
@@ -3,10 +3,6 @@ include "root" {
   expose = true
 }
 
-terraform {
-  source = "${get_repo_root()}/deployment/modules/distributor"
-}
-
 inputs = merge(
   include.root.locals,
   {

--- a/deployment/live/serving/prod/terragrunt.hcl
+++ b/deployment/live/serving/prod/terragrunt.hcl
@@ -1,25 +1,17 @@
-include {
-  path = find_in_parent_folders()
+include "root" {
+  path   = find_in_parent_folders()
+  expose = true
 }
 
 terraform {
-  source = "${get_path_to_repo_root()}/deployment/modules/distributor"
-}
-
-locals {
-  env           = "prod"
-  common_vars   = read_terragrunt_config(find_in_parent_folders())
-  witnesses_raw = yamldecode(file("${get_path_to_repo_root()}/config/witnesses-${local.env}.yaml"))
-  witnessArgs   = [for w in local.witnesses_raw.Witnesses : "--witkey=${w}"]
+  source = "${get_repo_root()}/deployment/modules/distributor"
 }
 
 inputs = merge(
-  local.common_vars.locals,
+  include.root.locals,
   {
-    env                      = local.env
     distributor_docker_image = "us-central1-docker.pkg.dev/checkpoint-distributor/distributor-docker-prod/distributor:v0.1.1"
-    distributor_docker_image = "us-central1-docker.pkg.dev/checkpoint-distributor/distributor-docker-prod/distributor:v0.1.0"
-    extra_args               = local.witnessArgs
+    extra_args               = include.root.locals.witnessArgs
   }
 )
 

--- a/deployment/live/serving/prod/terragrunt.hcl
+++ b/deployment/live/serving/prod/terragrunt.hcl
@@ -3,10 +3,6 @@ include "root" {
   expose = true
 }
 
-terraform {
-  source = "${get_repo_root()}/deployment/modules/distributor"
-}
-
 inputs = merge(
   include.root.locals,
   {

--- a/deployment/live/serving/prod/terragrunt.hcl
+++ b/deployment/live/serving/prod/terragrunt.hcl
@@ -7,14 +7,19 @@ terraform {
 }
 
 locals {
-  common_vars = read_terragrunt_config(find_in_parent_folders())
+  env           = "prod"
+  common_vars   = read_terragrunt_config(find_in_parent_folders())
+  witnesses_raw = yamldecode(file("${get_path_to_repo_root()}/config/witnesses-${local.env}.yaml"))
+  witnessArgs   = [for w in local.witnesses_raw.Witnesses : "--witkey=${w}"]
 }
 
 inputs = merge(
   local.common_vars.locals,
   {
-    env                      = "prod"
+    env                      = local.env
     distributor_docker_image = "us-central1-docker.pkg.dev/checkpoint-distributor/distributor-docker-prod/distributor:v0.1.1"
+    distributor_docker_image = "us-central1-docker.pkg.dev/checkpoint-distributor/distributor-docker-prod/distributor:v0.1.0"
+    extra_args               = local.witnessArgs
   }
 )
 

--- a/deployment/live/serving/terragrunt.hcl
+++ b/deployment/live/serving/terragrunt.hcl
@@ -2,6 +2,8 @@ locals {
   project_id  = "checkpoint-distributor"
   region      = "us-central1"
   env         = path_relative_to_include()
+  witnesses_raw = yamldecode(file("${get_repo_root()}/config/witnesses-${local.env}.yaml"))
+  witnessArgs   = [for w in local.witnesses_raw.Witnesses : "--witkey=${w}"]
 }
 
 remote_state {

--- a/deployment/live/serving/terragrunt.hcl
+++ b/deployment/live/serving/terragrunt.hcl
@@ -1,3 +1,7 @@
+terraform {
+  source = "${get_repo_root()}/deployment/modules/distributor"
+}
+
 locals {
   project_id  = "checkpoint-distributor"
   region      = "us-central1"

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -34,4 +34,4 @@ services:
       db:
         condition: service_healthy
     volumes:
-      - ./config/witnesses.yaml:/var/config/witnesses.yaml
+      - ./config/witnesses-dev.yaml:/var/config/witnesses.yaml


### PR DESCRIPTION
With this I've removed the final use of the baked-in witnesses config. Witnesses must now be configured explicitly, either via flags or a config file.

The single witnesses.yaml file has been sharded into 3 files: one per environment. These files are the canonical description of witnesses allowed for each environment. The terraform script reads the environment-specific file and configures the flags appropriately.

This seems like a good place to leave the witness list until such time that we can resource the design and rollout of defining them in a log (or logs).
