### PR TITLE
Move dependabot to weekly

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -32,4 +32,7 @@ updates:
 - package-ecosystem: docker
   directory: /cmd
   schedule:
-    interval: daily
+    interval: weekly
+  ignore:
+    versions:
+      - "> 1.22.99" # Only allow updates that are 1.22.x


### PR DESCRIPTION
Also try to prevent it from bumping the minor version of Go until we explicitly want it to do that. I wanted to set this to > 1.22 but I have no idea how that will be interpreted. It could assume that 1.22.4 > 1.22 and thus keep us stuck. So I've picked an abnormally large patch version and hopefully that is clear.
