### PR TITLE
Add a cli option to get a witness' checkpoints

### DIFF
--- a/cmd/client/client.go
+++ b/cmd/client/client.go
@@ -35,6 +35,7 @@ import (
 var (
 	baseURL = flag.String("base_url", "https://api.transparency.dev", "The base URL of the distributor")
 	n       = flag.Uint("n", 2, "The desired number of witness signatures for each log")
+	witness = flag.String("w", "", "Show the latest checkpoints for this witness short name")
 )
 
 func main() {
@@ -58,10 +59,20 @@ func main() {
 			continue
 		}
 		fmt.Printf("Log %q (%s)\n", log.Verifier.Name(), l)
-		cp, err := d.GetCheckpointN(l, *n)
-		if err != nil {
-			fmt.Printf("❌️ Could not get checkpoint.%d: %v\n", *n, err)
-			continue
+		var cp []byte
+		var err error
+		if *witness == "" {
+			cp, err = d.GetCheckpointN(l, *n)
+			if err != nil {
+				fmt.Printf("❌️ Could not get checkpoint.%d: %v\n", *n, err)
+				continue
+			}
+		} else {
+			cp, err = d.GetCheckpointWitness(l, *witness)
+			if err != nil {
+				fmt.Printf("❌️ Could not get checkpoint: %v\n", err)
+				continue
+			}
 		}
 		_, _, cpN, err := f_log.ParseCheckpoint(cp, log.Origin, log.Verifier, maps.Values(ws)...)
 		if err != nil {


### PR DESCRIPTION
Add a new -w option that takes a witness name and returns the latest checkpoints signed by this witness
This is useful for witness admin (or ArmoredWitness custodians) to check that their witness is working.

Usage:

```console
$ go run ./cmd/client -w ArmoredWitness-dry-sunset
Fetching checkpoints from distributor...
╾╾╾╾╾╾╾╾╾╾╾╾╾╾╾╾╾╾╾╾╾╾╾╾╾╾╾╾╾╾╾╾╾╾╾╾╾╾╾╾╾╾╾╾╾╾╾╾╾╾╾╾╾╾╾╾╾╾╾╾╾╾╾╾╾╾╾╾╾╾
Log "transparency.dev-aw-ftlog-ci-3" (0b963db2162e516836b4afbf8ff75aca120af717d3b93a332464cd5af4146e99)
✅ Got checkpoint:

transparency.dev/armored-witness/firmware_transparency/ci/3
59
kOFMkeamIdrYFLx5zbWFhflak6dlEEDOU++fxYEZMBw=

— transparency.dev-aw-ftlog-ci-3 P2iVIt3Jsaha3E2i0MHdKZ6fgYJTgXO86nUsxKPVq6uTwRSclTSh/ELnDGbNL+XDyD3EkWIdL2AGGNmbN7IN2rB/7gE=
— ArmoredWitness-dry-sunset uS6j90LXi2YAAAAAyvMVEmnYJJ8c4ohhwW9YeG6yXgnGEmC8AB0K7LDFweW2hXQloeUGerCO86ei+NKR7/DYXkxQFh1J6pXr0oXDAQ==

Witness timestamps:
— ArmoredWitness-dry-sunset: 1 month ago (2024-07-08T14:10:42+02:00)
[...]
```