### PR TITLE
Specify content encoding on text/plain responses

### DIFF
--- a/cmd/internal/http/server.go
+++ b/cmd/internal/http/server.go
@@ -93,7 +93,7 @@ func (s *Server) getCheckpointN(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, "failed to get checkpoint", httpForCode(status.Code(err)))
 		return
 	}
-	w.Header().Set("Content-Type", "text/plain")
+	w.Header().Set("Content-Type", "text/plain; charset=utf-8")
 	if _, err := w.Write(chkpt); err != nil {
 		glog.Errorf("w.Write(): %v", err)
 	}
@@ -112,7 +112,7 @@ func (s *Server) getCheckpointWitness(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, "failed to get checkpoint", httpForCode(status.Code(err)))
 		return
 	}
-	w.Header().Set("Content-Type", "text/plain")
+	w.Header().Set("Content-Type", "text/plain; charset=utf-8")
 	if _, err := w.Write(chkpt); err != nil {
 		glog.Errorf("w.Write(): %v", err)
 	}


### PR DESCRIPTION
Without the content encoding type specified, the `—` character renders as `â€”` in Chrome.

https://api.transparency.dev/distributor/v0/logs/2371c7aa76ca0d588c7f21317b789071bb63593bd2c3d7b02ca5842f03680fda/checkpoint.14
<img width="1099" alt="image" src="https://github.com/user-attachments/assets/18333743-fb35-4fc9-8073-430a1720c12f">
