### PR TITLE
Made gatekeeping of new checkpoints more permissive

### DIFF
--- a/cmd/internal/distributor/distributor.go
+++ b/cmd/internal/distributor/distributor.go
@@ -214,9 +214,9 @@ func (d *Distributor) Distribute(ctx context.Context, logID, witID string, nextR
 				reportInconsistency(oldBs, nextRaw)
 				return status.Errorf(codes.Internal, "old checkpoint for tree size %d had hash %x but new one has %x", newCP.Size, oldCP.Hash, newCP.Hash)
 			}
-			// Nothing to do; checkpoint is equivalent to the old one so avoid DB writes.
-			counterCheckpointUpdateSuccess.WithLabelValues(witID).Inc()
-			return nil
+			// This used to short-circuit here to avoid writes. However, having the most recently witnessed
+			// timestamp available is beneficial to demonstrate freshness.
+			// If there are too many equivalent writes happening, then consider implementing a throttle here.
 		}
 	}
 

--- a/config/config.go
+++ b/config/config.go
@@ -81,7 +81,8 @@ func ParseWitnessesConfig(y []byte) (map[string]note.Verifier, error) {
 	}
 	ws := make(map[string]note.Verifier)
 	for _, w := range witCfg.Witnesses {
-		wSigV, err := f_note.NewVerifierForCosignatureV1(w)
+		// TODO(mhutchinson): Upgrade this to f_note.NewVerifierForCosignatureV1
+		wSigV, err := note.NewVerifier(w)
 		if err != nil {
 			return nil, fmt.Errorf("invalid witness public key: %v", err)
 		}


### PR DESCRIPTION
This change has two main aspects, but they are related. The first is that we now overwrite a checkpoint from a witness even if we have previously seen one of the same size. This allows infrequently updated checkpoints to have fresh witness signature timestamps. The other change is to only check the witness note signature, and not the cosignatureV1. This is a temporary change to allow signatures from the fixed implementation of this signer (https://github.com/transparency-dev/formats/pull/153) to propagate into the distributor storage.
