### PR TITLE
Switch back to using cosignature

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -81,8 +81,7 @@ func ParseWitnessesConfig(y []byte) (map[string]note.Verifier, error) {
 	}
 	ws := make(map[string]note.Verifier)
 	for _, w := range witCfg.Witnesses {
-		// TODO(mhutchinson): Upgrade this to f_note.NewVerifierForCosignatureV1
-		wSigV, err := note.NewVerifier(w)
+		wSigV, err := f_note.NewVerifierForCosignatureV1(w)
 		if err != nil {
 			return nil, fmt.Errorf("invalid witness public key: %v", err)
 		}


### PR DESCRIPTION
This will reinstate timestamps in the witness signatures. This was dropped in #233 as a temporary measure to facilitate a transition between timestamp endianness. Any sigs that aren't verified are dropped, and thus the currently deployed distributors will drop the cosignature signatures.

If we want to support keeping both witness signatures around, we'll have to do some more engineering to have multiple verifiers per witness. We would also need to look at the merging code to ensure we only merge similar signatures. It seems easier to just drop the non-timestamped sigs on entry.
