### PR TITLE
Add sigsum log to distributor

### DIFF
--- a/config/logs.yaml
+++ b/config/logs.yaml
@@ -21,3 +21,5 @@ Logs:
     PublicKey: transparency.dev-aw-ftlog-ci-2+f77c6276+AZXqiaARpwF4MoNOxx46kuiIRjrML0PDTm+c7BLaAMt6
   - Origin: transparency.dev/armored-witness/firmware_transparency/ci/3
     PublicKey: transparency.dev-aw-ftlog-ci-3+3f689522+Aa1Eifq6rRC8qiK+bya07yV1fXyP156pEMsX7CFBC6gg
+  - Origin: sigsum.org/v1/tree/44ad38f8226ff9bd27629a41e55df727308d0a1cd8a2c31d3170048ac1dd22a1
+    PublicKey: sigsum.org/v1/tree/44ad38f8226ff9bd27629a41e55df727308d0a1cd8a2c31d3170048ac1dd22a1+682b49db+AQ7H4WhDEZsSA3enOROsasvC0D2CQy4sNrhBsJqVhB8l


### PR DESCRIPTION
Might as well have these checkpoints be pushable to the distributor too.
