### PR TITLE
Fixed interval for online checks

### DIFF
--- a/deployment/modules/monitoring/main.tf
+++ b/deployment/modules/monitoring/main.tf
@@ -92,7 +92,7 @@ resource "google_monitoring_dashboard" "witness_dashboard" {
             "xyChart": {
               "dataSets": [{
                 "timeSeriesQuery": {
-                  "prometheusQuery": "max by (instance_id, witness_id) (rate(distributor_update_checkpoint_request{configuration_name='distributor-service-${var.env}'}[$${__interval}])) > bool 0"
+                  "prometheusQuery": "max by (instance_id, witness_id) (rate(distributor_update_checkpoint_request{configuration_name='distributor-service-${var.env}'}[5m])) > bool 0"
                 },
                 "plotType": "STACKED_AREA"
               }],
@@ -111,7 +111,7 @@ resource "google_monitoring_dashboard" "witness_dashboard" {
             "xyChart": {
               "dataSets": [{
                 "timeSeriesQuery": {
-                  "prometheusQuery": "sum (max by (instance_id, witness_id) (rate(distributor_update_checkpoint_request{configuration_name='distributor-service-${var.env}'}[$${__interval}])) > bool 0) * 100 / ${var.num_expected_devices}"
+                  "prometheusQuery": "sum (max by (instance_id, witness_id) (rate(distributor_update_checkpoint_request{configuration_name='distributor-service-${var.env}'}[5m])) > bool 0) * 100 / ${var.num_expected_devices}"
                 },
                 "plotType": "STACKED_AREA"
               }],


### PR DESCRIPTION
This PR makes the "are the devices online" graphs look for life signs over a fixed interval of 5m, rather than an interval defined by whatever range the UI is currently graphing.

This is needed because the interval between distribution attempts is fixed, and relatively infrequent, so we start to see "bumps" of unavailability once you zoom in to ranges of ~1h or less.