### PR TITLE
Add terragrunt cfg for OmniGCP

### DIFF
--- a/deployment/live/cloudbuild/dev/terragrunt.hcl
+++ b/deployment/live/cloudbuild/dev/terragrunt.hcl
@@ -6,8 +6,9 @@ include "root" {
 inputs = merge(
   include.root.locals,
   {
-    cloud_run_service   = "distributor-service-dev"
-    slack_template_json = file("slack.json")
+    distributor_cloud_run_service = "distributor-service-dev"
+    witness_cloud_run_service     = "witness-service-dev"
+    slack_template_json           = file("slack.json")
   }
 )
 

--- a/deployment/live/cloudbuild/terragrunt.hcl
+++ b/deployment/live/cloudbuild/terragrunt.hcl
@@ -3,9 +3,9 @@ terraform {
 }
 
 locals {
-  project_id  = "checkpoint-distributor"
-  region      = "us-central1"
-  env         = path_relative_to_include()
+  project_id = "checkpoint-distributor"
+  region     = "us-central1"
+  env        = path_relative_to_include()
 }
 
 remote_state {
@@ -18,7 +18,7 @@ remote_state {
     prefix   = "${path_relative_to_include()}-terraform.tfstate"
 
     gcs_bucket_labels = {
-      name  = "terraform_state_storage"
+      name = "terraform_state_storage"
     }
   }
 }

--- a/deployment/live/monitoring/ci/terragrunt.hcl
+++ b/deployment/live/monitoring/ci/terragrunt.hcl
@@ -7,7 +7,7 @@ inputs = merge(
   include.root.locals,
   {
     alert_lt_num_witness_threshold = 0
-    num_expected_devices = 5
+    num_expected_devices           = 5
   }
 )
 

--- a/deployment/live/monitoring/dev/terragrunt.hcl
+++ b/deployment/live/monitoring/dev/terragrunt.hcl
@@ -7,7 +7,7 @@ inputs = merge(
   include.root.locals,
   {
     alert_lt_num_witness_threshold = 0
-    num_expected_devices = 2
+    num_expected_devices           = 2
   }
 )
 

--- a/deployment/live/monitoring/prod/terragrunt.hcl
+++ b/deployment/live/monitoring/prod/terragrunt.hcl
@@ -7,8 +7,8 @@ inputs = merge(
   include.root.locals,
   {
     alert_lt_num_witness_threshold = 10
-    alert_enable_num_witness = false
-    num_expected_devices = 15
+    alert_enable_num_witness       = false
+    num_expected_devices           = 15
   }
 )
 

--- a/deployment/live/monitoring/terragrunt.hcl
+++ b/deployment/live/monitoring/terragrunt.hcl
@@ -19,7 +19,7 @@ remote_state {
     prefix   = "${path_relative_to_include()}/terraform.tfstate"
 
     gcs_bucket_labels = {
-      name  = "terraform_state_storage"
+      name = "terraform_state_storage"
     }
   }
 }

--- a/deployment/live/serving/terragrunt.hcl
+++ b/deployment/live/serving/terragrunt.hcl
@@ -3,9 +3,9 @@ terraform {
 }
 
 locals {
-  project_id  = "checkpoint-distributor"
-  region      = "us-central1"
-  env         = path_relative_to_include()
+  project_id    = "checkpoint-distributor"
+  region        = "us-central1"
+  env           = path_relative_to_include()
   witnesses_raw = yamldecode(file("${get_repo_root()}/config/witnesses-${local.env}.yaml"))
   witnessArgs   = [for w in local.witnesses_raw.Witnesses : "--witkey=${w}"]
 }
@@ -20,7 +20,7 @@ remote_state {
     prefix   = "${path_relative_to_include()}/terraform.tfstate"
 
     gcs_bucket_labels = {
-      name  = "terraform_state_storage"
+      name = "terraform_state_storage"
     }
   }
 }

--- a/deployment/live/witness/README.md
+++ b/deployment/live/witness/README.md
@@ -2,15 +2,16 @@
 
 The directories under here contain the top-level terragrunt files for the deployment environments.
 
-In all cases, before deploying for the first time, you MUST have created the witness public and
-private keys or the `terragrunt apply` will fail.
+In all cases, before deploying for the first time, you MUST have created the witness `private` key
+and stored it in Secret Manager, or the `terragrunt apply` will fail.
 
-The keys can be generated and stored in Secret Manager from a shell on machine with appropriate
-gcloud auth, e.g. CloudShell.
-The example command below will generate a public and private note key-pair, using the provided
-witness name, and will use those to create and populate the initial version of two Secret Manager
-secrets called `witness_public_XXX` and `witness_secret_XXX` respectively, where XXX is the name
-of the target deployment environment.
+> [!Note]
+> While the witness binary itself doesn't need the `public` key, *you will* in order to share it
+> with others.
+
+Below is a `bash` snippet which will generate and store both the public and private key in Secret
+Manager under secrets called `witness_public_XXX` and `witness_secret_XXX` respectively, where
+```XXX``` is the name of the target deployment environment.
 
 ```bash
 $ export TARGET="dev" # This MUST match the name of the directory you're deploying

--- a/deployment/live/witness/README.md
+++ b/deployment/live/witness/README.md
@@ -1,0 +1,26 @@
+# Witness deployment
+
+The directories under here contain the top-level terragrunt files for the deployment environments.
+
+In all cases, before deploying for the first time, you MUST have created the witness public and
+private keys or the `terragrunt apply` will fail.
+
+The keys can be generated and stored in Secret Manager from a shell on machine with appropriate
+gcloud auth, e.g. CloudShell.
+The example command below will generate a public and private note key-pair, using the provided
+witness name, and will use those to create and populate the initial version of two Secret Manager
+secrets called `witness_public_XXX` and `witness_secret_XXX` respectively, where XXX is the name
+of the target deployment environment.
+
+```bash
+$ export TARGET="dev" # This MUST match the name of the directory you're deploying
+$ export WITNESS_NAME="..." # This is the witness name we're generating keys for. It should follow the schemaless-url recommendation from `tlog-witness`.
+$ go run github.com/transparency-dev/serverless-log/cmd/generate_keys@HEAD \
+    --key_name="${WITNESS_NAME}" \
+    --print | 
+    tee >(grep -v PRIVATE | gcloud secrets create witness_public_${TARGET} --data-file=-) | 
+    grep PRIVATE | 
+    gcloud secrets create witness_secret_${TARGET} --data-file=- 
+Created version [1] of the secret [witness_public_dev].
+Created version [1] of the secret [witness_secret_dev].
+```

--- a/deployment/live/witness/dev/terragrunt.hcl
+++ b/deployment/live/witness/dev/terragrunt.hcl
@@ -1,0 +1,13 @@
+include "root" {
+  path   = find_in_parent_folders("root.hcl")
+  expose = true
+}
+
+inputs = merge(
+  include.root.locals,
+  {
+    witness_docker_image = "us-central1-docker.pkg.dev/checkpoint-distributor/distributor-docker-dev/witness:latest"
+    ephemeral = true
+  }
+)
+

--- a/deployment/live/witness/root.hcl
+++ b/deployment/live/witness/root.hcl
@@ -1,0 +1,24 @@
+terraform {
+  source = "${get_repo_root()}/deployment/modules/witness"
+}
+
+locals {
+  project_id = "checkpoint-distributor"
+  region     = "us-central1"
+  env        = path_relative_to_include()
+}
+
+remote_state {
+  backend = "gcs"
+
+  config = {
+    project  = local.project_id
+    location = local.region
+    bucket   = "${local.project_id}-witness-${local.env}-terraform-state"
+    prefix   = "${path_relative_to_include()}/terraform.tfstate"
+
+    gcs_bucket_labels = {
+      name = "terraform_state_storage"
+    }
+  }
+}

--- a/deployment/modules/cloudbuild/outputs.tf
+++ b/deployment/modules/cloudbuild/outputs.tf
@@ -29,7 +29,12 @@ output "cloudbuild_trigger_id" {
   value       = google_cloudbuild_trigger.distributor_docker.id
 }
 
-output "docker_image" {
-  description = "The address of the docker image that will be built"
-  value       = local.docker_image
+output "distributor_docker_image" {
+  description = "The address of the distributor docker image that will be built"
+  value       = local.distributor_docker_image
+}
+
+output "witness_docker_image" {
+  description = "The address of the witness docker image that will be built"
+  value       = local.witness_docker_image
 }

--- a/deployment/modules/cloudbuild/variables.tf
+++ b/deployment/modules/cloudbuild/variables.tf
@@ -29,8 +29,13 @@ variable "env" {
   type        = string
 }
 
-variable "cloud_run_service" {
-  description = "The name of the cloud run service that new images should be pushed to"
+variable "distributor_cloud_run_service" {
+  description = "The name of the cloud run service running the distributor that new distributor images should be pushed to"
+  type        = string
+}
+
+variable "witness_cloud_run_service" {
+  description = "The name of the cloud run service running the witness that new witness images should be pushed to"
   type        = string
 }
 

--- a/deployment/modules/witness/main.tf
+++ b/deployment/modules/witness/main.tf
@@ -1,4 +1,4 @@
-/*ec
+/*
  * Copyright 2022 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/deployment/modules/witness/main.tf
+++ b/deployment/modules/witness/main.tf
@@ -1,0 +1,205 @@
+/*ec
+ * Copyright 2022 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+# Project data
+provider "google" {
+  project = var.project_id
+}
+
+data "google_project" "project" {
+  project_id = var.project_id
+}
+
+# This will be configured by terragrunt when deploying
+terraform {
+  backend "gcs" {}
+  required_providers {
+    google = {
+      source  = "hashicorp/google"
+      version = "6.0.1"
+    }
+    google-beta = {
+      source  = "hashicorp/google-beta"
+      version = "6.0.1"
+    }
+  }
+}
+
+# Enable Secret Manager API
+resource "google_project_service" "secretmanager_api" {
+  service            = "secretmanager.googleapis.com"
+  disable_on_destroy = false
+}
+
+# Enable Spanner
+resource "google_project_service" "spanner_api" {
+  service            = "spanner.googleapis.com"
+  disable_on_destroy = false
+}
+
+# Enable Cloud Run API
+resource "google_project_service" "cloudrun_api" {
+  service            = "run.googleapis.com"
+  disable_on_destroy = false
+}
+
+data "google_secret_manager_secret" "witness_secret" {
+  secret_id = "witness_secret_${var.env}"
+}
+
+data "google_secret_manager_secret_version" "witness_secret_data" {
+  secret = data.google_secret_manager_secret.witness_secret.id
+}
+
+# Update service accounts to allow secret access
+resource "google_secret_manager_secret_iam_member" "secretaccess_compute_witness" {
+  secret_id = data.google_secret_manager_secret.witness_secret.id
+  role      = "roles/secretmanager.secretAccessor"
+  member    = "serviceAccount:${data.google_project.project.number}-compute@developer.gserviceaccount.com" # Project's compute service account
+}
+
+resource "google_spanner_instance" "witness_spanner" {
+  name             = "witness-${var.env}"
+  config           = "regional-${var.region}"
+  display_name     = "Witness ${var.env}"
+  processing_units = 100
+
+  force_destroy = var.ephemeral
+  depends_on = [
+    google_project_service.spanner_api,
+  ]
+}
+
+resource "google_spanner_database" "witness_db" {
+  instance = google_spanner_instance.witness_spanner.name
+  name     = "witness_db_${var.env}"
+
+  deletion_protection = !var.ephemeral
+}
+
+resource "google_spanner_database_iam_member" "database" {
+  instance = google_spanner_instance.witness_spanner.name
+  database = google_spanner_database.witness_db.name
+  role     = "roles/spanner.databaseAdmin"
+
+  member = "serviceAccount:${data.google_project.project.number}-compute@developer.gserviceaccount.com" # Project's compute service account
+}
+
+locals {
+  spanner_db_full = "projects/${var.project_id}/instances/${google_spanner_instance.witness_spanner.name}/databases/${google_spanner_database.witness_db.name}"
+}
+
+###
+### Set up Cloud Run service
+###
+resource "google_service_account" "cloudrun_service_account" {
+  account_id   = "cloudrun-witness-${var.env}-sa"
+  display_name = "Service Account for Witness Cloud Run (${var.env})"
+}
+
+resource "google_project_iam_member" "iam_act_as" {
+  project = var.project_id
+  role    = "roles/iam.serviceAccountUser"
+  member  = "serviceAccount:${google_service_account.cloudrun_service_account.email}"
+}
+resource "google_project_iam_member" "iam_metrics_writer" {
+  project = var.project_id
+  role    = "roles/monitoring.metricWriter"
+  member  = "serviceAccount:${google_service_account.cloudrun_service_account.email}"
+}
+resource "google_project_iam_member" "iam_spanner_client" {
+  project = var.project_id
+  role    = "roles/spanner.databaseUser"
+  member  = "serviceAccount:${google_service_account.cloudrun_service_account.email}"
+}
+resource "google_project_iam_member" "iam_service_agent" {
+  project = var.project_id
+  role    = "roles/run.serviceAgent"
+  member  = "serviceAccount:${google_service_account.cloudrun_service_account.email}"
+}
+resource "google_project_iam_member" "iam_secret_accessor" {
+  project = var.project_id
+  role    = "roles/secretmanager.secretAccessor"
+  member  = "serviceAccount:${google_service_account.cloudrun_service_account.email}"
+}
+
+resource "google_cloud_run_v2_service" "default" {
+  name         = "witness-service-${var.env}"
+  location     = var.region
+  launch_stage = "GA"
+
+
+  template {
+    service_account = google_service_account.cloudrun_service_account.email
+    scaling {
+      min_instance_count = 1
+      max_instance_count = 3
+    }
+    max_instance_request_concurrency = 1000
+    containers {
+      image = var.witness_docker_image
+      name  = "witness"
+      args = concat([
+        "--logtostderr",
+        "--v=1",
+        "--listen=:8090",
+        "--spanner=${local.spanner_db_full}",
+        "--signer_private_key_secret_name=${data.google_secret_manager_secret_version.witness_secret_data.name}"
+      ], var.extra_args)
+      ports {
+        container_port = 8090
+      }
+
+      startup_probe {
+        initial_delay_seconds = 1
+        timeout_seconds       = 1
+        period_seconds        = 10
+        failure_threshold     = 3
+        tcp_socket {
+          port = 8090
+        }
+      }
+    }
+    containers {
+      image      = "us-docker.pkg.dev/cloud-ops-agents-artifacts/cloud-run-gmp-sidecar/cloud-run-gmp-sidecar:1.0.0"
+      name       = "collector"
+      depends_on = ["witness"]
+    }
+  }
+  client = "terraform"
+  depends_on = [
+    google_project_service.secretmanager_api,
+    google_project_service.cloudrun_api,
+    google_project_service.spanner_api,
+    google_project_iam_member.iam_act_as,
+    google_project_iam_member.iam_metrics_writer,
+    google_project_iam_member.iam_spanner_client,
+    google_project_iam_member.iam_service_agent,
+    google_project_iam_member.iam_secret_accessor,
+  ]
+
+  deletion_protection = !var.ephemeral
+}
+
+resource "google_cloud_run_service_iam_binding" "default" {
+  location = google_cloud_run_v2_service.default.location
+  service  = google_cloud_run_v2_service.default.name
+  role     = "roles/run.invoker"
+  members = [
+    "allUsers"
+  ]
+}
+

--- a/deployment/modules/witness/outputs.tf
+++ b/deployment/modules/witness/outputs.tf
@@ -1,0 +1,21 @@
+/**
+ * Copyright 2022 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+output "witness_uri" {
+  description = "The main URI in which this Service is serving traffic."
+  value       = google_cloud_run_v2_service.default.uri
+}
+

--- a/deployment/modules/witness/variables.tf
+++ b/deployment/modules/witness/variables.tf
@@ -1,0 +1,47 @@
+/**
+ * Copyright 2019 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+variable "project_id" {
+  description = "The project ID to host the cluster in"
+  type        = string
+}
+
+variable "region" {
+  description = "The region to host the cluster in"
+  type        = string
+}
+
+variable "env" {
+  description = "Unique identifier for the env, e.g. ci or prod"
+  type        = string
+}
+
+variable "witness_docker_image" {
+  description = "The full image URL (path & tag) for the witness docker image to deploy"
+  type        = string
+}
+
+variable "extra_args" {
+  description = "Extra arguments to be provided to the witness invoked in cloud run"
+  type        = list(string)
+  default     = []
+}
+
+variable "ephemeral" {
+  description = "Set to true if this is a CI/temporary deploy"
+  type        = bool
+  default     = false
+}


### PR DESCRIPTION
This PR adds:
- A cloud build trigger for building the OmniGCP docker image from the `witness` repo.
- A witness terraform module and terragrunt configs for spinning it up in dev.

Towards transparency-dev/witness#386.