### PR TITLE
Metrics must be on :8080

### DIFF
--- a/deployment/modules/feeder/main.tf
+++ b/deployment/modules/feeder/main.tf
@@ -86,11 +86,11 @@ resource "google_cloud_run_v2_service" "default" {
       args = concat([
         "--logtostderr",
         "--v=1",
-        "--metrics_listen=:8081",
+        "--metrics_listen=:8080",
         "--max_qps=${var.max_qps}",
       ], var.extra_args)
      ports {
-        container_port = 8081
+        container_port = 8080
       }
 
       startup_probe {
@@ -99,7 +99,7 @@ resource "google_cloud_run_v2_service" "default" {
         period_seconds        = 10
         failure_threshold     = 3
         tcp_socket {
-          port = 8081
+          port = 8080
         }
       }
 


### PR DESCRIPTION
The Google Cloud Run default config assumes that all containers are serving metrics on `:8080`, so we need to do so.

See https://github.com/GoogleCloudPlatform/run-gmp-sidecar?tab=readme-ov-file#create-the-cloud-run-service-default-config for more info.